### PR TITLE
TCP_QUICKACK

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -18,6 +18,7 @@
 #include "gameQuit.h"
 #include "coffTimeDateStamp.h"
 #include "screenshot.h"
+#include "gameSocket.h"
 
 using namespace std;
 
@@ -255,6 +256,14 @@ BOOL APIENTRY DllMain(HMODULE hModule,
             MessageBoxW(NULL, utf8_to_utf16(u8"Failed to create hook for screenShot function.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
             return FALSE;
         }
+        if (MH_CreateHookApi(L"WSOCK32.DLL", "send", &detoured_send, reinterpret_cast<LPVOID*>(&p_original_send)) != MH_OK) {
+            MessageBoxW(NULL, utf8_to_utf16(u8"Failed to create hook for gameSocket send function.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+            return FALSE;
+        }
+        if (MH_CreateHookApi(L"WSOCK32.DLL", "recv", &detoured_recv, reinterpret_cast<LPVOID*>(&p_original_recv)) != MH_OK) {
+            MessageBoxW(NULL, utf8_to_utf16(u8"Failed to create hook for gameSocket recv function.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+            return FALSE;
+        }
         if (MH_EnableHook(MH_ALL_HOOKS) != MH_OK) {
             MessageBoxW(NULL, utf8_to_utf16(u8"Failed when enabling hooks.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
             return FALSE;
@@ -268,6 +277,14 @@ BOOL APIENTRY DllMain(HMODULE hModule,
         if (lpReserved == NULL) {
             if (MH_DisableHook(MH_ALL_HOOKS) != MH_OK) {
                 MessageBoxW(NULL, utf8_to_utf16(u8"Failed when to disable hooks. Game might crash later.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+                return FALSE;
+            }
+            if (MH_RemoveHook(p_original_recv) != MH_OK) {
+                MessageBoxW(NULL, utf8_to_utf16(u8"Failed when to remove hook for gameSocket recv function. Game might crash later.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
+                return FALSE;
+            }
+            if (MH_RemoveHook(p_original_send) != MH_OK) {
+                MessageBoxW(NULL, utf8_to_utf16(u8"Failed when to remove hook for gameSocket send function. Game might crash later.").data(), utf8_to_utf16(u8"UnitXP Service Pack 3").data(), MB_OK | MB_ICONINFORMATION | MB_SYSTEMMODAL);
                 return FALSE;
             }
             if (MH_RemoveHook(p_CTgaFile_Write_0x5a4810) != MH_OK) {

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -203,7 +203,7 @@ int __fastcall detoured_UnitXP(void* L) {
                 return 1;
             }
             if (subcmd == "additionalInformation") {
-                lua_pushstring(L, "Konaka-main");
+                lua_pushstring(L, "Konaka-tcp_quickack");
                 return 1;
             }
         }

--- a/gameSocket.cpp
+++ b/gameSocket.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+#include <cstdint>
+
+#include <winsock2.h>
+#include <mstcpip.h>
+
+#include "gameSocket.h"
+
+extern SEND_RECV p_original_send = NULL;
+extern SEND_RECV p_original_recv = NULL;
+
+static void setSocketOpt(SOCKET s) {
+	const DWORD noDelay = TRUE;
+	setsockopt(s, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&noDelay), sizeof(noDelay));
+
+	int quickAck = 1;
+	DWORD dummy = 0;
+	WSAIoctl(s, SIO_TCP_SET_ACK_FREQUENCY, &quickAck, sizeof(quickAck), NULL, 0, &dummy, NULL, NULL);
+}
+
+int PASCAL FAR detoured_send(SOCKET s, const char FAR* buf, int len, int flags) {
+	setSocketOpt(s);
+	return p_original_send(s, buf, len, flags);
+}
+
+int PASCAL FAR detoured_recv(SOCKET s, const char FAR* buf, int len, int flags) {
+	setSocketOpt(s);
+	return p_original_recv(s, buf, len, flags);
+}

--- a/gameSocket.h
+++ b/gameSocket.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <winsock2.h>
+
+// Attempt to disable TCP delayed acknowledgment
+// Attempt to disable Nagle's algorithm (The 1.12 game already doing this)
+// - https://en.wikipedia.org/wiki/TCP_delayed_acknowledgment
+// - https://en.wikipedia.org/wiki/Nagle%27s_algorithm
+// - https://cygwin.com/git/?p=newlib-cygwin.git;a=commitdiff;h=ee2292413792f0360d357bc200c5e947eae516e6
+
+typedef int(PASCAL FAR* SEND_RECV)(SOCKET, const char FAR*, int, int);
+
+extern SEND_RECV p_original_send;
+extern SEND_RECV p_original_recv;
+
+int PASCAL FAR detoured_send(SOCKET s, const char FAR* buf, int len, int flags);
+int PASCAL FAR detoured_recv(SOCKET s, const char FAR* buf, int len, int flags);


### PR DESCRIPTION
Windows implements [TCP delayed acknowledgment](https://en.wikipedia.org/wiki/TCP_delayed_acknowledgment) by default.

Consider WoW works in a message based communication system, according to [a document](https://community.opentext.com/cfs-file/__key/telligent-evolution-components-attachments/00-236-01-00-01-24-70-60/Tech-Note-_2D00_-TCP-ACK-Delay-Performance.pdf), there could be a 200ms delayed ACK at the last transport segment of each message.

Microsoft added [a switch](https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.10240.0/shared/mstcpip.h#L165) to turn off this behavior. However to use this switch, it requires WSAIoctl() which is in Winsock 2. The game is linked with Winsock 1.

This pull request would turn off the switch in mod.